### PR TITLE
010 add --npms --npm --github to open action

### DIFF
--- a/cmd/open.js
+++ b/cmd/open.js
@@ -4,6 +4,19 @@ const got = require('got');
 const opn = require('opn');
 const handleError = require('./util/handleError');
 
+function getLink(argv, res) {
+    const links = res.body.collected.metadata.links;
+
+    if (argv.link === 'npms') {
+        return `https://npms.io/search?term=${argv.package}`;
+    }
+    if (argv.link === 'npm') {
+        return links.npm;
+    }
+
+    return links.repository || links.npm;
+}
+
 exports.command = 'open <package>';
 exports.describe = 'Opens the package in your browser.';
 exports.builder = (yargs) =>
@@ -29,24 +42,8 @@ exports.builder = (yargs) =>
 
 exports.handler = (argv) => {
     got(`https://api.npms.io/module/${encodeURIComponent(argv.package)}`, { json: true })
-    .then((res) => getService(argv, res))
+    .then((res) => getLink(argv, res))
     .then((link) => opn(link, { wait: false }))
     .then(() => { process.exitCode = 0; })
     .catch((err) => handleError(err));
 };
-
-function getService(argv, res) {
-    const links = res.body.collected.metadata.links;
-
-    if (argv.link === 'npms') {
-        return `https://npms.io/search?term=${argv.package}`;
-    }
-    if (argv.link === 'npm') {
-        return links.npm;
-    }
-    if (argv.link === 'auto') {
-        return links.repository || links.npm;
-    }
-
-    return links.repository || links.npm;
-}

--- a/cmd/open.js
+++ b/cmd/open.js
@@ -11,10 +11,10 @@ exports.builder = (yargs) =>
     .strict()
     .usage('Usage: $0 open <package> [options]\n\nOpens the package in your browser..')
     .example('$0 open gulp', 'Opens "gulp" package using auto source')
-    .example('$0 open --link npms gulp', 'Opens "gulp" package in `https://npms.io` service')
+    .example('$0 open gulp --link npms', 'Opens "gulp" package in `https://npms.io` service')
     .option('link', {
         alias: 'l',
-        describe: 'choose link',
+        describe: 'Choose link',
         choices: ['auto', 'npm', 'npms'],
         default: 'auto',
     })

--- a/cmd/open.js
+++ b/cmd/open.js
@@ -10,25 +10,16 @@ exports.builder = (yargs) =>
     yargs
     .strict()
     .usage('Usage: $0 open <package> [options]\n\nOpens the package in your browser..')
-    .example('$0 open gulp', 'Opens "gulp" package')
-    .example('$0 open --npms gulp', 'Opens "gulp" package in `https://npms.io` service')
-    .example('$0 open --npm gulp', 'Opens "gulp" package in `https://npmjs.org` service')
-    .example('$0 open --github gulp', 'Opens "gulp" package in `https://github.com` service')
+    .example('$0 open gulp', 'Opens "gulp" package using auto source')
+    .example('$0 open --link npms gulp', 'Opens "gulp" package in `https://npms.io` service')
+    .example('$0 open --link npm gulp', 'Opens "gulp" package in `https://npmjs.org` service')
+    .example('$0 open --link auto gulp', 'Opens "gulp" package in `https://github.com` service')
     .demand(1, 1)
     .options({
-        npms: {
-            describe: 'Open "gulp" package in `https://npms.io` service',
-            type: 'boolean',
+        link: {
+            describe: 'Open <package> using supplied link source',
+            type: 'string',
         },
-        npm: {
-            describe: 'Open "gulp" package in `https://npmjs.org` service',
-            type: 'boolean',
-        },
-        github: {
-            describe: 'Open "gulp" package in `https://github.com` service',
-            default: true,
-            type: 'boolean',
-        }
     });
 
 exports.handler = (argv) => {
@@ -40,7 +31,11 @@ exports.handler = (argv) => {
 };
 
 function getService(argv, res) {
-    if (argv.npms) { return `https://npms.io/search?term=${argv.package}`; }
-    if (argv.npm) { return res.body.collected.metadata.links.npm; }
-    return res.body.collected.metadata.links.repository || res.body.collected.metadata.links.npm;
+    const links = res.body.collected.metadata.links;
+
+    if (argv.link) {
+        if (argv.link === 'npms') { return `https://npms.io/search?term=${argv.package}`; }
+        if (argv.link === 'npm') { return links.npm; }
+    }
+    return links.repository || links.npm || links.homepage;
 }

--- a/cmd/open.js
+++ b/cmd/open.js
@@ -11,12 +11,36 @@ exports.builder = (yargs) =>
     .strict()
     .usage('Usage: $0 open <package> [options]\n\nOpens the package in your browser..')
     .example('$0 open gulp', 'Opens "gulp" package')
-    .demand(1, 1);
+    .example('$0 open --npms gulp', 'Opens "gulp" package in `https://npms.io` service')
+    .example('$0 open --npm gulp', 'Opens "gulp" package in `https://npmjs.org` service')
+    .example('$0 open --github gulp', 'Opens "gulp" package in `https://github.com` service')
+    .demand(1, 1)
+    .options({
+        npms: {
+            describe: 'Open "gulp" package in `https://npms.io` service',
+            type: 'boolean',
+        },
+        npm: {
+            describe: 'Open "gulp" package in `https://npmjs.org` service',
+            type: 'boolean',
+        },
+        github: {
+            describe: 'Open "gulp" package in `https://github.com` service',
+            default: true,
+            type: 'boolean',
+        }
+    });
 
 exports.handler = (argv) => {
     got(`https://api.npms.io/module/${encodeURIComponent(argv.package)}`, { json: true })
-    .then((res) => res.body.collected.metadata.links.repository || res.body.collected.metadata.links.npm)
+    .then((res) => getService(argv, res))
     .then((link) => opn(link, { wait: false }))
     .then(() => { process.exitCode = 0; })
     .catch((err) => handleError(err));
 };
+
+function getService(argv, res) {
+    if (argv.npms) { return `https://npms.io/search?term=${argv.package}`; }
+    if (argv.npm) { return res.body.collected.metadata.links.npm; }
+    return res.body.collected.metadata.links.repository || res.body.collected.metadata.links.npm;
+}

--- a/cmd/open.js
+++ b/cmd/open.js
@@ -12,13 +12,18 @@ exports.builder = (yargs) =>
     .usage('Usage: $0 open <package> [options]\n\nOpens the package in your browser..')
     .example('$0 open gulp', 'Opens "gulp" package using auto source')
     .example('$0 open --link npms gulp', 'Opens "gulp" package in `https://npms.io` service')
-    .example('$0 open --link npm gulp', 'Opens "gulp" package in `https://npmjs.org` service')
-    .example('$0 open --link auto gulp', 'Opens "gulp" package in `https://github.com` service')
+    .option('link', {
+        alias: 'l',
+        describe: 'choose link',
+        choices: ['auto', 'npm', 'npms'],
+        default: 'auto',
+    })
     .demand(1, 1)
     .options({
         link: {
             describe: 'Open <package> using supplied link source',
             type: 'string',
+            default: 'auto',
         },
     });
 
@@ -33,9 +38,15 @@ exports.handler = (argv) => {
 function getService(argv, res) {
     const links = res.body.collected.metadata.links;
 
-    if (argv.link) {
-        if (argv.link === 'npms') { return `https://npms.io/search?term=${argv.package}`; }
-        if (argv.link === 'npm') { return links.npm; }
+    if (argv.link === 'npms') {
+        return `https://npms.io/search?term=${argv.package}`;
     }
-    return links.repository || links.npm || links.homepage;
+    if (argv.link === 'npm') {
+        return links.npm;
+    }
+    if (argv.link === 'auto') {
+        return links.repository || links.npm;
+    }
+
+    return links.repository || links.npm;
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "lint": "eslint '{*.js,cmd/**/*.js,test/**/*.js}' --ignore-pattern=test/coverage",
     "test": "mocha",
     "test-cov": "istanbul cover --dir test/coverage _mocha && echo Coverage lies in test/coverage/lcov-report/index.html",
-    "test-travis": "istanbul cover _mocha --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test-travis": "istanbul cover --dir test/coverage _mocha --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "lint": "eslint '{*.js,cmd/**/*.js,test/**/*.js}' --ignore-pattern=test/coverage",
     "test": "mocha",
     "test-cov": "istanbul cover --dir test/coverage _mocha && echo Coverage lies in test/coverage/lcov-report/index.html",
-    "test-travis": "istanbul cover --dir test/coverage _mocha --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test-travis": "istanbul cover _mocha --report lcovonly && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   }
 }

--- a/test/open.spec.js
+++ b/test/open.spec.js
@@ -27,7 +27,6 @@ describe('open', () => {
     });
 
     it('should open module\'s repository in browser using `--link npm` service', () => {
-        // this will be here
         nock('https://api.npms.io')
         .get('/module/gulp')
         .reply(200, JSON.stringify(require('./fixtures/open/gulp.json')));

--- a/test/open.spec.js
+++ b/test/open.spec.js
@@ -7,7 +7,7 @@ const betray = require('betray');
 const exec = require('./util/exec');
 
 describe('open', () => {
-    it('should open module\'s repository in browser using npms service', () => {
+    it('should open module\'s repository in browser using `--link npms` service', () => {
         // this will be here
         nock('https://api.npms.io')
         .get('/module/gulp')
@@ -17,7 +17,7 @@ describe('open', () => {
             unref: () => {},
         }));
 
-        return exec(['open', '--npms', 'gulp'])
+        return exec(['open', '--link', 'npms', 'gulp'])
         .then((output) => {
             expect(output.stdout).to.equal('');
             expect(output.stderr).to.equal('');
@@ -27,7 +27,7 @@ describe('open', () => {
         });
     });
 
-    it('should open module\'s repository in browser using npm service', () => {
+    it('should open module\'s repository in browser using `--link npm` service', () => {
         // this will be here
         nock('https://api.npms.io')
         .get('/module/gulp')
@@ -37,7 +37,7 @@ describe('open', () => {
             unref: () => {},
         }));
 
-        return exec(['open', '--npm', 'gulp'])
+        return exec(['open', '--link', 'npm', 'gulp'])
         .then((output) => {
             expect(output.stdout).to.equal('');
             expect(output.stderr).to.equal('');
@@ -47,7 +47,7 @@ describe('open', () => {
         });
     });
 
-    it('should open module\'s repository in browser using github service', () => {
+    it('should open module\'s repository in browser using `--link auto` service', () => {
         nock('https://api.npms.io')
         .get('/module/gulp')
         .reply(200, JSON.stringify(require('./fixtures/open/gulp.json')));
@@ -56,7 +56,7 @@ describe('open', () => {
             unref: () => {},
         }));
 
-        return exec(['open', 'gulp'])
+        return exec(['open', '--link', 'auto', 'gulp'])
         .then((output) => {
             expect(output.stdout).to.equal('');
             expect(output.stderr).to.equal('');
@@ -66,7 +66,7 @@ describe('open', () => {
         });
     });
 
-    it('should open module\'s npm page in browser using github service if it has no repository', () => {
+    it('should open module\'s npm page in browser using auto service if it has no repository', () => {
         nock('https://api.npms.io')
         .get('/module/query')
         .reply(200, JSON.stringify(require('./fixtures/open/query.json')));

--- a/test/open.spec.js
+++ b/test/open.spec.js
@@ -8,7 +8,6 @@ const exec = require('./util/exec');
 
 describe('open', () => {
     it('should open module\'s repository in browser using `--link npms` service', () => {
-        // this will be here
         nock('https://api.npms.io')
         .get('/module/gulp')
         .reply(200, JSON.stringify(require('./fixtures/open/gulp.json')));

--- a/test/open.spec.js
+++ b/test/open.spec.js
@@ -7,7 +7,47 @@ const betray = require('betray');
 const exec = require('./util/exec');
 
 describe('open', () => {
-    it('should open module\'s repository in browser', () => {
+    it('should open module\'s repository in browser using npms service', () => {
+        // this will be here
+        nock('https://api.npms.io')
+        .get('/module/gulp')
+        .reply(200, JSON.stringify(require('./fixtures/open/gulp.json')));
+
+        const betrayed = betray(cp, 'spawn', () => ({
+            unref: () => {},
+        }));
+
+        return exec(['open', '--npms', 'gulp'])
+        .then((output) => {
+            expect(output.stdout).to.equal('');
+            expect(output.stderr).to.equal('');
+
+            expect(betrayed.invoked).to.equal(1);
+            expect(betrayed.invocations[0][1]).to.contain('https://npms.io/search?term=gulp');
+        });
+    });
+
+    it('should open module\'s repository in browser using npm service', () => {
+        // this will be here
+        nock('https://api.npms.io')
+        .get('/module/gulp')
+        .reply(200, JSON.stringify(require('./fixtures/open/gulp.json')));
+
+        const betrayed = betray(cp, 'spawn', () => ({
+            unref: () => {},
+        }));
+
+        return exec(['open', '--npm', 'gulp'])
+        .then((output) => {
+            expect(output.stdout).to.equal('');
+            expect(output.stderr).to.equal('');
+
+            expect(betrayed.invoked).to.equal(1);
+            expect(betrayed.invocations[0][1]).to.contain('https://www.npmjs.com/package/gulp');
+        });
+    });
+
+    it('should open module\'s repository in browser using github service', () => {
         nock('https://api.npms.io')
         .get('/module/gulp')
         .reply(200, JSON.stringify(require('./fixtures/open/gulp.json')));
@@ -26,7 +66,7 @@ describe('open', () => {
         });
     });
 
-    it('should open module\'s npm page in browser if it has no repository', () => {
+    it('should open module\'s npm page in browser using github service if it has no repository', () => {
         nock('https://api.npms.io')
         .get('/module/query')
         .reply(200, JSON.stringify(require('./fixtures/open/query.json')));


### PR DESCRIPTION
- added `open --npms` option to open archive in `npms.io` service
- added `open --npm` option to open archive in `npmjs.org` service
- added `open --github` alias option to work same as open command (open in `github.com` service)
- added appropriate tests
- fixed `npm run test-travis` script to store coverage report in `test/coverage` (it was creating `coverage` in package directory)

NOTE: All tests were executed repeated 100 times to assure no leaks, etc.

ISSUE: I did find that if I added `describe.only` to `open.spec.js` to test in isolation, it produced errors.  I can look at  this further if you all deem this an issue.